### PR TITLE
fix: default value for jsonencoded setting

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -211,7 +211,7 @@ resource "azurerm_monitor_data_collection_rule" "dcr" {
           streams            = extension.value.streams
           input_data_sources = extension.value.input_data_sources
           extension_name     = extension.value.extension_name
-          extension_json     = jsonencode(extension.value.extension_json)
+          extension_json     = length(try(each.value.extension_json, {})) > 0 ? jsonencode(each.value.extension_json) : null
           name               = try(extension.value.name, extension.key)
         }
       }


### PR DESCRIPTION
## Description

* When no value is given for extension_json, default to null instead of jsonencode({}) as this is causing issues for extensions

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Change Log

* When no value is given for settings/protected_settings, default to null instead of jsonencode({}) as this is causing issues for extensions

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)
